### PR TITLE
Customization from caller template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # web_one2many_selectable_10
+## Usage in templates:
+
+    <field name="One2many_name" widget="one2many_selectable" caption="your button caption" action="server_action" callback="javascript_callback">
+
+If defined, "server_action" will be RPC called and executed by server
+If defined, "javascript_callback" will be executed client side after "server_action" is executed server side,
+if also defined. "javascript_callback" will be sent results returned from "server_action" if any.

--- a/web_one2many_selectable_10/static/src/js/widgets.js
+++ b/web_one2many_selectable_10/static/src/js/widgets.js
@@ -1,67 +1,118 @@
+/*
+    Usage in templates:
+
+    <field name="One2many_name" widget="one2many_selectable" action="server_action" callback="javascript_callback>
+
+    If defined, "server_action" will be RPC called and executed by server
+    If defined, "javascript_callback" will be executed client side after "server_action" is executed server side,
+    if also defined. "javascript_callback" will be sent results returned from "server_action" if any.
+*/
+
 odoo.define('web_one2many_selectable_10.form_widgets', function (require) {
-	"use strict";
+    "use strict";
 
-	var core = require('web.core');
-	var form_common = require('web.form_common');
-	var _t = core._t;
-	var QWeb = core.qweb;
-	var Model = require('web.Model');
-	var FieldOne2Many = core.form_widget_registry.get('one2many');
+    var core = require('web.core');
+    var _t = core._t;
+    var Model = require('web.Model');
+    var FieldOne2Many = core.form_widget_registry.get('one2many');
 
+    function executeFunctionByName(functionName, context /*, args */) {
+        var args = Array.prototype.slice.call(arguments, 2);
+        var namespaces = functionName.split(".");
+        var func = namespaces.pop();
+        for (var i = 0; i < namespaces.length; i++) {
+            context = context[namespaces[i]];
+        }
+        return context[func].apply(context, args);
+    }
 
-	var One2ManySelectable = FieldOne2Many.extend({
-		// my custom template for unique char field
-		template: 'One2ManySelectable', 
+    var One2ManySelectable = FieldOne2Many.extend({
+        template: 'One2ManySelectable',
 
-		multi_selection: true,
-		//button click
-		events: {
-			"click .cf_button_confirm": "action_selected_lines",
-		},
-		start: function() 
-	    {
-	    	this._super.apply(this, arguments);
-			var self=this;			
-		   },
-		//passing ids to function
-		action_selected_lines: function()
-		{		
-			var self=this;
-			var selected_ids = self.get_selected_ids_one2many();
-			if (selected_ids.length === 0)
-			{
-				this.do_warn(_t("You must choose at least one record."));
-				return false;
-			}
-			var model_obj=new Model(this.dataset.model); 
-			//you can hardcode model name as: new Model("module.model_name");
-			//you can change the function name below
-			/* you can use the python function to get the IDS
-			      @api.multi
-				def bulk_verify(self):
-        				for record in self:
-            				print record
-			*/
-			model_obj.call('bulk_verify',[selected_ids],{context:self.dataset.context})
-			.then(function(result){
-			});
-		},
-		//collecting the selected IDS from one2manay list
-		get_selected_ids_one2many: function ()
-		{
-			var ids =[];
-			this.$el.find('td.o_list_record_selector input:checked')
-					.closest('tr').each(function () {
-						
-						ids.push(parseInt($(this).context.dataset.id));
-						console.log(ids);
-			});
-			return ids;
-		},
+        events: {
+            'click .web_one2many_selectable': 'button_pressed',
+        },
 
+        multi_selection: true,
 
-	});
-	// register unique widget, because Odoo does not know anything about it
-	//you can use <field name="One2many_ids" widget="x2many_selectable"> for call this widget
-	core.form_widget_registry.add('one2many_selectable', One2ManySelectable);
+        // Retrieve options from caller template to have them available in the widget 'One2ManySelectable' template
+        init: function () {
+            this._super.apply(this, arguments);
+
+            // Default options
+            this.options = {
+                caption: 'Apply',
+                action: null,
+                callback: null
+            }
+
+            // User defined options from field attributes in caller template
+            if (arguments[1].attrs.hasOwnProperty('options')) {
+                this.options = JSON.parse(arguments[1].attrs.options);
+            }
+
+            // Translate caption
+            this.options.caption = _t(this.options.caption)
+        },
+
+        start: function () {
+            this._super.apply(this, arguments);
+        },
+
+        // Catch button pressed event, collect IDs, call action server side, then callback client side if defined.
+        button_pressed: function () {
+            var self = this;
+            var selected_ids = self.get_selected_ids_one2many();
+            if (selected_ids.length === 0) {
+                this.do_warn(_t("You must choose at least one record."));
+                return false;
+            }
+
+            // If an action was defined in template, let's call this action server side
+            if (this.options.action) {
+                /* Here is a python example function to parse the selected objects
+
+                    @api.multi
+                    def your_action_name(self):
+                         for record in self:
+                             print record
+                */
+
+                var model_obj = new Model(this.dataset.model);
+                model_obj.call(this.options.action, [selected_ids], {context: self.dataset.context})
+                    .then(function (result) {
+                        if (self.options.callback) {
+                            // If a callback was defined in template, let's call this callback client side with
+                            // results from server call above.
+                            executeFunctionByName(self.options.callback, window, result);
+                        } else {
+                            // Else simply refresh the display for the selected records
+                            var controller = self.get_active_view().controller;
+                            $.each(selected_ids,function(){
+                                controller.reload_record(controller.records.get(this));
+                            });
+                        }
+                    });
+            }
+        },
+
+        // Collect the object IDs for checked checkboxes
+        get_selected_ids_one2many: function () {
+            var ids = [];
+            this.$el.find('td.o_list_record_selector input:checkbox:checked').closest('tr').each(function () {
+                ids.push(parseInt($(this).context.dataset.id));
+            });
+            return ids;
+        }
+
+    });
+
+    // Register this widget
+    core.form_widget_registry.add('one2many_selectable', One2ManySelectable);
+
+    // Make the widget available for other add-ons
+    return {
+        One2ManySelectable: One2ManySelectable
+    }
+
 });


### PR DESCRIPTION
- [x] Adapted add-on in order to:

- define button caption from the `<field>` tag in caller template (`caption` attribute)
- define server-side action from the `<field>` tag in caller template (`action` attribute)
- define client-side callback with results returned by action from the `<field>` tag in caller template (`callback` attribute)
- if no `callback` is defined automatically proceed to selected field display update

- [x] Added `<field>` declaration usage in script

- [x] Made the widget available (extendable) to children widgets.
